### PR TITLE
chore: move gh org & bump dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 
-GO_VERSION: &go_version '1.23.10'
+GO_VERSION: &go_version '1.24.6'
 GORELEASER_VERSION: &goreleaser_version 'v1.26.2'
 GO_MOD_CACHE_KEY: &go_mod_cache_key 'go-mod-1'
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,7 +24,7 @@ builds:
         goarch: arm64
     ldflags:
       - -s -w
-      - -X github.com/liftedinit/yaci/cmd/yaci.Version={{ .Version }}
+      - -X github.com/manifest-network/yaci/cmd/yaci.Version={{ .Version }}
 
 archives:
   - format: tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Start from the official Golang image to build our application.
-FROM golang:1.23 AS builder
+FROM golang:1.24 AS builder
 
 # Set the current working directory inside the container.
 WORKDIR /app

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
-BUILD_FLAGS := -ldflags "-X github.com/liftedinit/yaci/cmd/yaci.Version=$(VERSION)" -tags manifest
+BUILD_FLAGS := -ldflags "-X github.com/manifest-network/yaci/cmd/yaci.Version=$(VERSION)" -tags manifest
 
 #### Build ####
 build: ## Build the binary
@@ -23,7 +23,7 @@ test-e2e: ## Run end-to-end tests
 COV_ROOT="/tmp/yaci-coverage"
 COV_UNIT="${COV_ROOT}/unit"
 COV_E2E="${COV_ROOT}/e2e"
-COV_PKG="github.com/liftedinit/yaci/..."
+COV_PKG="github.com/manifest-network/yaci/..."
 
 coverage: ## Run tests with coverage
 	@echo "--> Creating GOCOVERDIR"
@@ -88,7 +88,7 @@ goimports_version=v0.26.0
 format: ## Run formatter (goimports)
 	@echo "--> Running goimports"
 	@go install golang.org/x/tools/cmd/goimports@$(goimports_version)
-	@find . -name '*.go' -exec goimports -w -local github.com/liftedinit/yaci {} \;
+	@find . -name '*.go' -exec goimports -w -local github.com/manifest-network/yaci {} \;
 
 .PHONY: format
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # yaci
 
-[![build](https://img.shields.io/circleci/build/github/liftedinit/yaci/main)](https://app.circleci.com/pipelines/github/liftedinit/yaci)
-[![coverage](https://img.shields.io/codecov/c/github/liftedinit/yaci)](https://app.codecov.io/gh/liftedinit/yaci)
-[![Go Report Card](https://goreportcard.com/badge/github.com/liftedinit/yaci)](https://goreportcard.com/report/github.com/liftedinit/yaci)
+[![build](https://img.shields.io/circleci/build/github/manifest-network/yaci/main)](https://app.circleci.com/pipelines/github/manifest-network/yaci)
+[![coverage](https://img.shields.io/codecov/c/github/manifest-network/yaci)](https://app.codecov.io/gh/manifest-network/yaci)
+[![Go Report Card](https://goreportcard.com/badge/github.com/manifest-network/yaci)](https://goreportcard.com/report/github.com/manifest-network/yaci)
 
 `yaci` is a command-line tool that connects to a gRPC server and extracts blockchain data.
 
@@ -12,7 +12,7 @@ Off-chain indexing of block & transaction data.
 
 ## Requirements
 
-- Go 1.23.5
+- Go 1.24.6
 - Docker & Docker Compose (optional)
 - CosmosSDK >= 0.50 (chain to index)
 
@@ -32,7 +32,7 @@ Off-chain indexing of block & transaction data.
 To install the `yaci` tool, you need to have Go installed on your system. Then, you can use the following command to install `yaci`:
 
 ```sh
-go install github.com/liftedinit/yaci@latest
+go install github.com/manifest-network/yaci@latest
 ```
 
 The `yaci` binary will be installed in the `$GOPATH/bin` directory.
@@ -151,7 +151,7 @@ The following PostgreSQL functions are available:
 The `yaci` tool parameters can be configured from the following sources
 
 - Environment variables (prefixed with `YACI_`)
-- Configuration file (`config.yaml`, `config.json`, `config.toml`, `config.hcl`, [~~`config.env`~~](https://github.com/liftedinit/yaci/issues/15) )
+- Configuration file (`config.yaml`, `config.json`, `config.toml`, `config.hcl`, [~~`config.env`~~](https://github.com/manifest-network/yaci/issues/15) )
 - Command-line flags
 
 The command-line flags have the highest priority, followed by the environment variables, and then the configuration file.

--- a/cmd/yaci/extract.go
+++ b/cmd/yaci/extract.go
@@ -8,8 +8,8 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/liftedinit/yaci/internal/client"
-	"github.com/liftedinit/yaci/internal/config"
+	"github.com/manifest-network/yaci/internal/client"
+	"github.com/manifest-network/yaci/internal/config"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )

--- a/cmd/yaci/extract_test.go
+++ b/cmd/yaci/extract_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/liftedinit/yaci/cmd/yaci"
+	"github.com/manifest-network/yaci/cmd/yaci"
 )
 
 func TestExtractCmd(t *testing.T) {

--- a/cmd/yaci/postgres.go
+++ b/cmd/yaci/postgres.go
@@ -6,14 +6,14 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jackc/pgx/v5/stdlib"
-	"github.com/liftedinit/yaci/internal/metrics"
-	"github.com/liftedinit/yaci/internal/output/postgresql"
-	"github.com/liftedinit/yaci/internal/utils"
+	"github.com/manifest-network/yaci/internal/metrics"
+	"github.com/manifest-network/yaci/internal/output/postgresql"
+	"github.com/manifest-network/yaci/internal/utils"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/liftedinit/yaci/internal/config"
-	"github.com/liftedinit/yaci/internal/extractor"
+	"github.com/manifest-network/yaci/internal/config"
+	"github.com/manifest-network/yaci/internal/extractor"
 )
 
 var PostgresRunE = func(cmd *cobra.Command, args []string) error {

--- a/cmd/yaci/postgres_test.go
+++ b/cmd/yaci/postgres_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/gruntwork-io/terratest/modules/docker"
 	"github.com/stretchr/testify/require"
 
-	"github.com/liftedinit/yaci/cmd/yaci"
-	"github.com/liftedinit/yaci/internal/testutil"
+	"github.com/manifest-network/yaci/cmd/yaci"
+	"github.com/manifest-network/yaci/internal/testutil"
 )
 
 const (

--- a/cmd/yaci/root_test.go
+++ b/cmd/yaci/root_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/liftedinit/yaci/cmd/yaci"
+	"github.com/manifest-network/yaci/cmd/yaci"
 )
 
 func executeCommand(root *cobra.Command, args ...string) (output string, err error) {

--- a/docker/infra/compose.yaml
+++ b/docker/infra/compose.yaml
@@ -23,7 +23,7 @@ services:
       retries: 5
 
   manifest-ledger:
-    image: ghcr.io/liftedinit/manifest-ledger:v1.0.3
+    image: ghcr.io/manifest-network/manifest-ledger:1.0.8
     volumes:
         - manifest-ledger-bin:/usr/bin
         - manifest-ledger-data:/persistent
@@ -68,7 +68,7 @@ services:
   # Setup some transactions on the blockchain
   manifest-ledger-tx:
     restart: no
-    image: ghcr.io/liftedinit/manifest-ledger:v1.0.3
+    image: ghcr.io/manifest-network/manifest-ledger:1.0.8
     volumes:
       - manifest-ledger-bin:/usr/bin
       - manifest-ledger-data:/persistent

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module github.com/liftedinit/yaci
+module github.com/manifest-network/yaci
 
-go 1.23.10
+go 1.24.6
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/liftedinit/yaci/internal/reflection"
+	"github.com/manifest-network/yaci/internal/reflection"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"

--- a/internal/extractor/block.go
+++ b/internal/extractor/block.go
@@ -7,11 +7,11 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/liftedinit/yaci/internal/client"
-	"github.com/liftedinit/yaci/internal/config"
-	"github.com/liftedinit/yaci/internal/models"
-	"github.com/liftedinit/yaci/internal/output"
-	"github.com/liftedinit/yaci/internal/utils"
+	"github.com/manifest-network/yaci/internal/client"
+	"github.com/manifest-network/yaci/internal/config"
+	"github.com/manifest-network/yaci/internal/models"
+	"github.com/manifest-network/yaci/internal/output"
+	"github.com/manifest-network/yaci/internal/utils"
 	"github.com/schollz/progressbar/v3"
 	"golang.org/x/sync/errgroup"
 )

--- a/internal/extractor/extractor.go
+++ b/internal/extractor/extractor.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/liftedinit/yaci/internal/client"
-	"github.com/liftedinit/yaci/internal/config"
-	"github.com/liftedinit/yaci/internal/output"
-	"github.com/liftedinit/yaci/internal/utils"
+	"github.com/manifest-network/yaci/internal/client"
+	"github.com/manifest-network/yaci/internal/config"
+	"github.com/manifest-network/yaci/internal/output"
+	"github.com/manifest-network/yaci/internal/utils"
 )
 
 const (
@@ -55,7 +55,7 @@ func setBlockRange(gRPCClient *client.GRPCClient, outputHandler output.OutputHan
 	if cfg.ReIndex {
 		slog.Info("Reindexing entire database...")
 		// TODO: Get the earliest block from the gRPC server
-		// See https://github.com/liftedinit/yaci/issues/28
+		// See https://github.com/manifest-network/yaci/issues/28
 		cfg.BlockStart = 1
 		earliestLocalBlock, err := outputHandler.GetEarliestBlock(gRPCClient.Ctx)
 		if err != nil {
@@ -69,7 +69,7 @@ func setBlockRange(gRPCClient *client.GRPCClient, outputHandler output.OutputHan
 
 	if cfg.BlockStart == 0 {
 		// TODO: Get the earliest block from the gRPC server
-		// See https://github.com/liftedinit/yaci/issues/28
+		// See https://github.com/manifest-network/yaci/issues/28
 		cfg.BlockStart = 1
 		latestLocalBlock, err := outputHandler.GetLatestBlock(gRPCClient.Ctx)
 		if err != nil {

--- a/internal/extractor/live.go
+++ b/internal/extractor/live.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/liftedinit/yaci/internal/client"
-	"github.com/liftedinit/yaci/internal/output"
-	"github.com/liftedinit/yaci/internal/utils"
+	"github.com/manifest-network/yaci/internal/client"
+	"github.com/manifest-network/yaci/internal/output"
+	"github.com/manifest-network/yaci/internal/utils"
 )
 
 // extractLiveBlocksAndTransactions monitors the chain and processes new blocks as they are produced.

--- a/internal/extractor/transaction.go
+++ b/internal/extractor/transaction.go
@@ -6,9 +6,9 @@ import (
 	"encoding/hex"
 	"fmt"
 
-	"github.com/liftedinit/yaci/internal/client"
-	"github.com/liftedinit/yaci/internal/models"
-	"github.com/liftedinit/yaci/internal/utils"
+	"github.com/manifest-network/yaci/internal/client"
+	"github.com/manifest-network/yaci/internal/models"
+	"github.com/manifest-network/yaci/internal/utils"
 )
 
 func extractTransactions(gRPCClient *client.GRPCClient, data map[string]interface{}, maxRetries uint) ([]*models.Transaction, error) {

--- a/internal/metrics/server.go
+++ b/internal/metrics/server.go
@@ -7,11 +7,11 @@ import (
 	"net"
 	"net/http"
 
-	"github.com/liftedinit/yaci/internal/metrics/collectors"
+	"github.com/manifest-network/yaci/internal/metrics/collectors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
-	_ "github.com/liftedinit/yaci/internal/metrics/collectors" // Import all collectors
+	_ "github.com/manifest-network/yaci/internal/metrics/collectors" // Import all collectors
 )
 
 func CreateMetricsServer(db *sql.DB, bech32Prefix, addr string) (*http.Server, error) {

--- a/internal/metrics/server_test.go
+++ b/internal/metrics/server_test.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/liftedinit/yaci/internal/metrics"
-	"github.com/liftedinit/yaci/internal/metrics/collectors"
+	"github.com/manifest-network/yaci/internal/metrics"
+	"github.com/manifest-network/yaci/internal/metrics/collectors"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/output/output_handler.go
+++ b/internal/output/output_handler.go
@@ -3,7 +3,7 @@ package output
 import (
 	"context"
 
-	"github.com/liftedinit/yaci/internal/models"
+	"github.com/manifest-network/yaci/internal/models"
 )
 
 type OutputHandler interface {

--- a/internal/output/postgresql/postgresql.go
+++ b/internal/output/postgresql/postgresql.go
@@ -15,7 +15,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jackc/pgx/v5/stdlib"
 
-	"github.com/liftedinit/yaci/internal/models"
+	"github.com/manifest-network/yaci/internal/models"
 )
 
 //go:embed migrations/*

--- a/internal/reflection/build_descriptor_test.go
+++ b/internal/reflection/build_descriptor_test.go
@@ -7,7 +7,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/descriptorpb"
 
-	"github.com/liftedinit/yaci/internal/reflection"
+	"github.com/manifest-network/yaci/internal/reflection"
 )
 
 func TestBuildFileDescriptorSet(t *testing.T) {

--- a/internal/reflection/fetch_descriptor_test.go
+++ b/internal/reflection/fetch_descriptor_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 
-	"github.com/liftedinit/yaci/internal/reflection"
-	"github.com/liftedinit/yaci/internal/testutil"
+	"github.com/manifest-network/yaci/internal/reflection"
+	"github.com/manifest-network/yaci/internal/testutil"
 )
 
 func TestFetchAllDescriptors(t *testing.T) {

--- a/internal/utils/auth.go
+++ b/internal/utils/auth.go
@@ -1,7 +1,7 @@
 package utils
 
 import (
-	"github.com/liftedinit/yaci/internal/client"
+	"github.com/manifest-network/yaci/internal/client"
 )
 
 const bech32PrefixMethod = "cosmos.auth.v1beta1.Query.Bech32Prefix"

--- a/internal/utils/block.go
+++ b/internal/utils/block.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"strconv"
 
-	"github.com/liftedinit/yaci/internal/client"
+	"github.com/manifest-network/yaci/internal/client"
 	"github.com/pkg/errors"
 )
 

--- a/internal/utils/grpc.go
+++ b/internal/utils/grpc.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/liftedinit/yaci/internal/client"
+	"github.com/manifest-network/yaci/internal/client"
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/reflect/protoreflect"

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/liftedinit/yaci/cmd/yaci"
+import "github.com/manifest-network/yaci/cmd/yaci"
 
 func main() {
 	yaci.Execute()


### PR DESCRIPTION
This pull request migrates the project from the `liftedinit/yaci` namespace to the new `manifest-network/yaci` namespace and upgrades the Go version to 1.24.6. The changes ensure that all references, dependencies, and documentation are updated to reflect the new repository location and Go version.

**Repository migration and reference updates:**

* Updated all import paths, module declarations, and repository URLs from `github.com/liftedinit/yaci` to `github.com/manifest-network/yaci` across source files, tests, configuration files, and documentation. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L1-R3) [[2]](diffhunk://#diff-5430d7ae989eb8d4f369d36f867e04a156e4a5b4da573deead61bf9960ae3898L11-R12) [[3]](diffhunk://#diff-191699dac33898f0be4c3832fc8296af90a76159e30543dbb62eb7cfa215e853L8-R8) [[4]](diffhunk://#diff-97c09e3987e15b33e585b5b47ec5f0ade84cc480fd09f24088a30c96fbda3cc5L9-R16) [[5]](diffhunk://#diff-61d07e7bdf5f9a6200e3881ba3676f439781cf8e2bddd5ba5cb7d2fe517fc9e3L14-R15) [[6]](diffhunk://#diff-3fb27ff5070f77bd15a8899c8a222ed676e5b83e306a3fbbfcc2d519663eb711L10-R10) [[7]](diffhunk://#diff-3b1f8149deb45d304c69c856bcd1b9b628961fb6000486cb39172a99cb8de514L10-R10) [[8]](diffhunk://#diff-70a734e3c7466d47c81ff96a08487bcfcd0636af3634c1a46bab2cfe6ad94034L10-R14) [[9]](diffhunk://#diff-55cf6eb44174abe7e7c9da3667b08be56c100814a3d59002072e4bcb72818bb0L7-R10) [[10]](diffhunk://#diff-55cf6eb44174abe7e7c9da3667b08be56c100814a3d59002072e4bcb72818bb0L58-R58) [[11]](diffhunk://#diff-55cf6eb44174abe7e7c9da3667b08be56c100814a3d59002072e4bcb72818bb0L72-R72) [[12]](diffhunk://#diff-9215881b73e5ac616085c7e1aba0b4258a10cd916f1c207347d060968f059807L7-R9) [[13]](diffhunk://#diff-77cefe1f0dfbb69b2969f40c4f8538e27fe93d46e591d6089f7151000d51599cL9-R11) [[14]](diffhunk://#diff-42c7bc9f1f4c699aabdad03f6522878dd826967a4d33545502a6d0a2a88cb927L10-R14) [[15]](diffhunk://#diff-28ff449fb16c9d45fa90fae140a58c8f50357bff252541601fb36ed2c36c773bL12-R13) [[16]](diffhunk://#diff-00e1cdabf6ab741929424a9930d7342ec4e750efb789fdadd90efbd3635f29beL6-R6) [[17]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L2-R2) [[18]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L26-R26) [[19]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L91-R91) [[20]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R5) [[21]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L15-R15) [[22]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L35-R35) [[23]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L154-R154) [[24]](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826L27-R27)

* Updated Docker Compose and image references to use the new `manifest-network` images and versions. [[1]](diffhunk://#diff-97fd5f0bb2ebe4f52f16e97711b361b8c131f323e7156fa003f4987c92ed1ba0L26-R26) [[2]](diffhunk://#diff-97fd5f0bb2ebe4f52f16e97711b361b8c131f323e7156fa003f4987c92ed1ba0L71-R71)

**Go version upgrade:**

* Upgraded the Go version in `go.mod`, `Dockerfile`, CircleCI config, and documentation from 1.23.x to 1.24.6. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L1-R3) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L2-R2) [[3]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L3-R3) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L15-R15)

These changes are primarily focused on project rebranding and technical alignment with the new repository and Go version. No functional or logic changes were introduced.