### PR TITLE
chore: update docs and release docker ci

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -2,7 +2,7 @@ name: Push Docker Images
 
 on:
   release:
-    types: [published, created, edited]
+    types: [published, created]
   push:
     tags:
     - '**'

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,0 +1,66 @@
+name: Push Docker Images
+
+on:
+  release:
+    types: [published, created, edited]
+  push:
+    tags:
+    - '**'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  chain-images:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          file: Dockerfile
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # yaci
 
-[![build](https://img.shields.io/circleci/build/github/manifest-network/yaci/main)](https://app.circleci.com/pipelines/github/manifest-network/yaci)
-[![coverage](https://img.shields.io/codecov/c/github/manifest-network/yaci)](https://app.codecov.io/gh/manifest-network/yaci)
+![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/manifest-network/yaci/ci.yml)
+[![codecov](https://codecov.io/github/manifest-network/yaci/graph/badge.svg?token=E0fP14l7Ct)](https://codecov.io/github/manifest-network/yaci)
 [![Go Report Card](https://goreportcard.com/badge/github.com/manifest-network/yaci)](https://goreportcard.com/report/github.com/manifest-network/yaci)
 
 `yaci` is a command-line tool that connects to a gRPC server and extracts blockchain data.


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for building and publishing Docker images, and updates the project badges in the `README.md` to reflect the migration from CircleCI to GitHub Actions. The most important changes are detailed below.

**CI/CD and Docker Publishing Improvements:**

* Added a new GitHub Actions workflow `.github/workflows/release-docker.yml` to automate building and publishing multi-architecture Docker images to GitHub Container Registry on release and tag events. This workflow also generates artifact attestations for enhanced supply chain security.

**Documentation and Badges:**

* Updated the `README.md` badges to display the status of the new GitHub Actions workflow and switched the code coverage badge to use the new Codecov URL, replacing the previous CircleCI and Codecov badge links.