### PR TITLE
fix: btree index tuple size

### DIFF
--- a/internal/metrics/collectors/total_payout_burn.go
+++ b/internal/metrics/collectors/total_payout_burn.go
@@ -15,7 +15,7 @@ const TotalPayoutBurnQuery = `
 		SELECT
 		  e.id,
 		  e.event_index,
-		  MAX(CASE WHEN e.attr_key = 'amount' THEN e.attr_value END) AS amount_raw,
+		  MAX(e.attr_value) FILTER (WHERE e.attr_key = 'amount') AS amount_raw,
 		  MAX(e.msg_index) AS msg_index
 		FROM api.events_main e
 		WHERE e.event_type = 'burn'

--- a/internal/metrics/collectors/total_pwr_minted.go
+++ b/internal/metrics/collectors/total_pwr_minted.go
@@ -16,7 +16,7 @@ const TotalPwrMintAmountQuery = `
 		    SELECT
 		  	e.id,
 		  	e.event_index,
-		  	MAX(CASE WHEN e.attr_key = 'amount' THEN e.attr_value END) AS amount_raw,
+			MAX(e.attr_value) FILTER (WHERE e.attr_key = 'amount') AS amount_raw,
 		  	MAX(e.msg_index) AS msg_index
 		    FROM api.events_main e
 		    WHERE e.event_type = 'tf_mint'

--- a/internal/output/postgresql/migrations/007_normalized_events.up.sql
+++ b/internal/output/postgresql/migrations/007_normalized_events.up.sql
@@ -1,5 +1,7 @@
 BEGIN;
 
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
 CREATE TABLE IF NOT EXISTS api.events_raw (
   id          varchar(64) NOT NULL,  -- tx id
   event_index bigint      NOT NULL,  -- 0-based within the tx
@@ -15,7 +17,7 @@ CREATE TABLE IF NOT EXISTS api.events_main (
   attr_index  bigint      NOT NULL,   -- 0-based within the event
   event_type  text        NOT NULL,
   attr_key    text        NOT NULL,
-  attr_value  text        NOT NULL,
+  attr_value  text,
   msg_index   bigint,                 -- nullable; from 'msg_index' attribute if present
   PRIMARY KEY (id, event_index, attr_index),
   FOREIGN KEY (id, event_index) REFERENCES api.events_raw(id, event_index) ON DELETE CASCADE
@@ -23,7 +25,7 @@ CREATE TABLE IF NOT EXISTS api.events_main (
 
 CREATE INDEX IF NOT EXISTS events_main_type_idx          ON api.events_main (event_type);
 CREATE INDEX IF NOT EXISTS events_main_msg_idx           ON api.events_main (msg_index);
-CREATE INDEX IF NOT EXISTS events_main_attr_key_val_idx  ON api.events_main (attr_key, attr_value);
+CREATE INDEX IF NOT EXISTS events_main_attr_key_val_sha256_idx ON api.events_main (attr_key, digest(attr_value, 'sha256'));
 CREATE INDEX IF NOT EXISTS events_main_id_idx            ON api.events_main (id);
 
 CREATE OR REPLACE FUNCTION api.extract_event_msg_index(ev jsonb)


### PR DESCRIPTION
This pull request introduces a few targeted improvements to the database schema and SQL queries related to event processing. The main focus is on optimizing attribute value handling and indexing for better performance and flexibility.

**Database schema and indexing improvements:**

* The `attr_value` column in the `api.events_main` table is now nullable instead of required, allowing for events without an attribute value.
* The index on `attr_key` and `attr_value` has been replaced with an index on `attr_key` and the SHA-256 digest of `attr_value`, improving performance for queries on large or sensitive values.
* The `pgcrypto` extension is now enabled to support digest functions needed for the new index.

**Query optimizations:**

* SQL queries in both `total_payout_burn.go` and `total_pwr_minted.go` have been updated to use the `FILTER` clause instead of `CASE WHEN` for extracting the `amount` attribute, making the queries more concise and potentially more efficient. [[1]](diffhunk://#diff-56bc03804677a38ad399edfc4417240bf6d8aebdd7ff48d118a075227e663b67L18-R18) [[2]](diffhunk://#diff-5dd94b81312bcdd4725671c74770d75338d67c901fd9a9b5c5443ee088647d89L19-R19)